### PR TITLE
Add SSL support for pyramid.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,10 @@ Pyramid (wsgiref.simple_server)
 By ``wsgiref.simple_server`` you must wrap the **WSGI application** in
 ``liveandletdie.WsgirefSimpleServer.wrap(app)``.
 
+If you set the ``ssl`` keyword argument to ``True``, the app will be run with
+a self-signed certificate, and the schema of the ``self.check_url``
+will be ``"https"``.
+
 .. code-block:: python
 
     # pyramid/app/main.py

--- a/sample_apps/pyramid/main.py
+++ b/sample_apps/pyramid/main.py
@@ -5,7 +5,11 @@ from pyramid.response import Response
 
 
 def home(request):
-    return Response('Home Pyramid')
+    content = 'Home Pyramid'
+    if request.scheme == 'https':
+        content += ' SSL'
+
+    return Response(content)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name=NAME,
     version='0.0.6',
     packages=find_packages(),
-    install_requires=['requests'],
+    install_requires=['requests', 'werkzeug'],
     package_data={'': ['*.txt', '*.rst']},
     author='Peter Hudec',
     author_email='peterhudec@peterhudec.com',

--- a/test_examples/pytest_example/tests.py
+++ b/test_examples/pytest_example/tests.py
@@ -21,6 +21,11 @@ APPS = {
         abspath('sample_apps/pyramid/main.py'),
         port=PORT
     ),
+    'Pyramid SSL': liveandletdie.WsgirefSimpleServer(
+        abspath('sample_apps/pyramid/main.py'),
+        port=PORT,
+        ssl=True
+    ),
     'Flask': liveandletdie.Flask(
         abspath('sample_apps/flask/main.py'),
         port=PORT

--- a/test_examples/unittest_example/tests.py
+++ b/test_examples/unittest_example/tests.py
@@ -63,6 +63,13 @@ class TestPyramid(unittest.TestCase):
 
 
 @test_decorator
+class TestPyramidSSL(unittest.TestCase):
+    EXPECTED_TEXT = 'Home Pyramid SSL'
+    app = liveandletdie.WsgirefSimpleServer(abspath('sample_apps/pyramid/main.py'), port=PORT,
+                                            ssl=True)
+
+
+@test_decorator
 class TestDjango(unittest.TestCase):
     EXPECTED_TEXT = 'Home Django'
     app = liveandletdie.Django(abspath('sample_apps/django/example'), port=PORT)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -86,3 +86,7 @@ class SSLBase(Base):
 class TestFlask(SSLBase):
     app_path = os.path.join(SAMPLE_APPS_DIR, 'flask', 'main.py')
     class_ = liveandletdie.Flask
+
+class TestPyramid(SSLBase):
+    app_path = os.path.join(SAMPLE_APPS_DIR, 'pyramid', 'main.py')
+    class_ = liveandletdie.Pyramid

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps=
     pytest
     pyopenssl
     requests
+    werkzeug
 setenv =
     PYTHONPATH={toxinidir}
     PYTHONWARNINGS=ignore


### PR DESCRIPTION
This change is based on the way Flask is configured to enable SSL. 

The real 'magic' is tweaking the request environment to make `wsgiref` set the scheme to https. Without this pyramid sets `request.scheme = 'http'` and in `authomatic` providers see request 'sources' as being insecure.